### PR TITLE
Add GitHub Actions workflow for Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automatically merge pull requests created by Dependabot. The workflow is designed to streamline dependency updates by enabling auto-merge for PRs opened by the Dependabot bot.

Automation for Dependabot PRs:

* Added `.github/workflows/dependabot-automerge.yml` to configure a workflow that triggers on `pull_request` events, checks if the actor is `dependabot[bot]`, and enables auto-merge using the GitHub CLI for those PRs.