### PR TITLE
Change Dependabot PR merge strategy to squash

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This pull request makes a small change to the Dependabot auto-merge workflow. The merge strategy for Dependabot pull requests has been switched from a regular merge to a squash merge, which will produce a cleaner commit history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependabot PRs are now auto-merged using squash, producing a single commit per dependency update for a cleaner history and easier reverts.
  * Reduces merge commit noise and improves blame clarity without altering triggers or permissions.
  * Applies only to automated dependency updates; no impact on features, performance, or release artifacts.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->