### PR TITLE
Add Playwright report directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ yarn-debug.log*
 yarn-error.log*
 *.log
 .sonarlint
+
+# playwright
+/playwright-report/
+/test-results/


### PR DESCRIPTION
## Summary
- Add `/playwright-report/` and `/test-results/` to .gitignore
- Prevents Playwright-generated test report directories from being committed

## Context
After consolidating the E2E workspace to the project root, we need to ensure Playwright's generated report directories are properly ignored.

🤖 Generated with [Claude Code](https://claude.ai/code)